### PR TITLE
fix: use @file import syntax for doc references in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,9 @@ The marker for this instruction is: 🤖
 
 Refer to these comprehensive guides for detailed information:
 
-- **[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)** - TDD workflow, setup, and development process
-- **[docs/TESTING.md](docs/TESTING.md)** - Testing strategies, patterns, and TDD implementation
-- **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** - System design and technical decisions
+- @docs/DEVELOPMENT.md — **[Development Guide](docs/DEVELOPMENT.md)** - TDD workflow, setup, and development process
+- @docs/TESTING.md — **[Testing Guide](docs/TESTING.md)** - Testing strategies, patterns, and TDD implementation
+- @docs/ARCHITECTURE.md — **[Architecture Guide](docs/ARCHITECTURE.md)** - System design and technical decisions
 
 ## TDD Standards
 


### PR DESCRIPTION
Use context file imports so AI agents automatically load the referenced documentation files as context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized documentation structure with enhanced labeling and clearer reference organization.
  * Improved and renamed guide titles including Development Guide, Testing Guide, and Architecture Guide for better clarity.
  * Updated descriptions to pair documentation links with more descriptive titles and formatting for improved navigation and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->