### PR TITLE
fix: add pre-commit guide to AGENTS.md documentation imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Refer to these comprehensive guides for detailed information:
 - @docs/DEVELOPMENT.md — **[Development Guide](docs/DEVELOPMENT.md)** - TDD workflow, setup, and development process
 - @docs/TESTING.md — **[Testing Guide](docs/TESTING.md)** - Testing strategies, patterns, and TDD implementation
 - @docs/ARCHITECTURE.md — **[Architecture Guide](docs/ARCHITECTURE.md)** - System design and technical decisions
+- @docs/PRECOMMIT.md — **[Pre-commit Guide](docs/PRECOMMIT.md)** - Hook configuration, usage, and troubleshooting
 
 ## TDD Standards
 


### PR DESCRIPTION
## Summary
- Add `@docs/PRECOMMIT.md` import to the Documentation Structure section in `AGENTS.md`
- The existing `docs/PRECOMMIT.md` was never referenced, so it was not loaded as agent context

## Test plan
- [x] Verify `AGENTS.md` renders correctly with the new doc link
- [x] Confirm the pre-commit guide is now included in agent context alongside the other docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Pre-commit Guide documentation covering hook configuration, usage, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->