### PR TITLE
docs(testing): add Meaningful Assertions best practice

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -719,6 +719,32 @@ Different test environments:
 3. **Test Independence**: Tests should not depend on each other
 4. **Test Data**: Use factories for consistent test data
 
+### Meaningful Assertions
+
+A test's assertions must **prove** the behavior its name claims — not imply it through a
+magic number plus an explanatory comment. A hard-coded count backed only by a comment can
+stay green after seed or configuration data changes while no longer demonstrating anything.
+Derive expected values from the mechanism under test rather than from brittle literals.
+
+```java
+// Weak: the name claims "without pagination" but only a magic count is asserted
+@Test
+void shouldFindAllOwnersWithoutPagination() {
+    // 10 > the 5-per-page limit
+    assertThat(this.owners.findByLastName("Smith")).hasSize(10);
+}
+
+// Strong: contrast the paginated page against the full result to prove the behavior,
+// and couple the expectation to the data via getTotalElements()
+@Test
+void shouldReturnAllMatchesRegardlessOfPageSize() {
+    Page<Owner> firstPage = this.owners.findByLastName("Smith", PageRequest.of(0, 5));
+    assertThat(firstPage.getContent()).hasSize(5);
+    assertThat(firstPage.getTotalElements()).isGreaterThan(5);
+    assertThat(this.owners.findByLastName("Smith")).hasSize((int) firstPage.getTotalElements());
+}
+```
+
 ### Performance Considerations
 
 1. **Test Speed**: Use in-memory databases for unit tests


### PR DESCRIPTION
## What

Adds a **Meaningful Assertions** best practice to `docs/TESTING.md`, under
`## Best Practices → Test Organization`. It states that a test's assertions must
*prove* the behavior the test's name claims — rather than imply it through a magic
number plus an explanatory comment — and shows a weak/strong example.

Docs-only change. No production or test code is touched.

## Why

### The concrete incident that prompted this

During review of a paginated-finder test, a test named for the *without-pagination*
behavior asserted only a magic count:

```java
@Test
void shouldFindAllOwnersWithoutPagination() {
    // 10 > the 5-per-page limit
    assertThat(this.owners.findByLastName("Smith")).hasSize(10);
}
```

The problem: **nothing in the assertions ties the result to the pagination mechanism.**
The `10` is opaque, and the only thing connecting it to "without pagination" is a comment.
If the seed/sample data changes (which it does — this repo ships sample data and multiple
DB profiles), the test can keep passing while no longer demonstrating the behavior its name
promises. A green test that proves nothing is worse than no test: it manufactures false
confidence.

### The principle

An assertion should express the *mechanism under test*, and expected values should be
**derived from behavior** rather than hard-coded. For the pagination case, that means
contrasting the paginated page (capped at the real UI page size) against the full result
set, and coupling the expectation to the data via `getTotalElements()`:

```java
@Test
void shouldReturnAllMatchesRegardlessOfPageSize() {
    Page<Owner> firstPage = this.owners.findByLastName("Smith", PageRequest.of(0, 5));
    assertThat(firstPage.getContent()).hasSize(5);
    assertThat(firstPage.getTotalElements()).isGreaterThan(5);
    assertThat(this.owners.findByLastName("Smith")).hasSize((int) firstPage.getTotalElements());
}
```

The contrast demonstrates the without-pagination behavior directly, and the expectation
follows the data instead of a brittle literal.

### Why it belongs in our shared testing standards

This repo mandates **strict TDD** (see `CLAUDE.md` and `docs/DEVELOPMENT.md`), where the
test *is* the specification. That only holds if a test genuinely validates its named claim —
otherwise the "spec" lies. This guidance is the natural completion of the existing
**"Naming Conventions: Use descriptive test method names"** best practice already in
`TESTING.md`: a descriptive name is only worth anything if the assertions back it up.

### Why this placement

It's a *principle*, so it lives under `## Best Practices` alongside the other prescriptive
guidance (Test Organization, Performance, Maintenance) rather than under
`### Assertion Patterns`, which is a catalog of assertion *styles* (AssertJ usage, HTTP
response validation) rather than rules. Kept concise to match the section's house style.

## Scope / risk

- Documentation only — no code, tests, or build config changed.
- No behavioral impact; safe to merge independent of any feature work.

## Provenance

This started as a personal review note and is being promoted into shared, reviewed team
documentation so every contributor (and every AI agent working in this repo) inherits the
standard rather than it living in one person's private notes.
