### PR TITLE
ci: add Claude Code PR review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,6 +45,10 @@ jobs:
         # on the credential actions/checkout leaves in .git/config. Disabling it
         # fails with "could not read Username for https://github.com" on any repo
         # that needs auth to fetch - which is every internal or private fork.
+        #
+        # Disabling it would not harden anything either: configureGitAuth then
+        # writes the token straight back via `git remote set-url origin
+        # https://x-access-token:$TOKEN@...` before the model ever runs.
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Skip review (no API key configured)

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,8 +10,10 @@ on:
 
 # track_progress has every run update the same PR comment, so overlapping runs
 # would race and produce conflicting summaries. Serialize per PR.
-# Only a new push supersedes a running review; a comment-triggered run waits its
-# turn instead, so an @claude request never cancels a review already underway.
+# A pull_request event supersedes a running review, since any of its action types
+# (opened, synchronize, ready_for_review, reopened) leaves an in-flight review
+# stale. A comment-triggered run waits its turn instead, so an @claude request
+# never cancels a review already underway.
 concurrency:
   group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -65,10 +65,10 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_REVIEW }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "@claude"
-          # Every run posts its own tracking comment, so a PR collects one per push.
-          # use_sticky_comment does not help while we authenticate with GITHUB_TOKEN:
-          # it only reuses a comment authored by claude[bot] (id 209825114), and ours
-          # come from github-actions[bot]. Collapsing them needs the Claude GitHub App.
+          # Each run posts its own tracking comment. use_sticky_comment cannot collapse
+          # them while we authenticate with GITHUB_TOKEN: it only reuses a comment whose
+          # author is claude[bot] (id 209825114), and ours come from github-actions[bot].
+          # The "Collapse superseded review comments" step below handles it instead.
           track_progress: true
           claude_args: |
             --model claude-sonnet-5
@@ -90,6 +90,77 @@ jobs:
             - A brief overview of the changes reviewed
             - Any issues found (or state that no issues were found)
             - A final verdict: LGTM or Changes Requested
+
+      # Runs after the review so a cancelled or failed run never destroys the only
+      # summary on the PR. Collapses rather than deletes: permalinks, reactions and
+      # the record of what Claude said about an earlier push all survive.
+      #
+      # Only push-triggered reviews supersede one another. A comment-triggered run is
+      # answering a question, so its comment is a conversation turn and is left alone -
+      # identified by looking up the event of the run that produced each comment.
+      #
+      # A run cancelled by cancel-in-progress can leave an orphaned "Claude Code is
+      # working..." comment behind. That body is matched too, so the next push sweeps it.
+      - name: Collapse superseded review comments
+        if: always() && env.CLAUDE_REVIEW_API_KEY != '' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          NAME: ${{ github.event.repository.name }}
+          PR: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # github-actions[bot] authors the tracking comment. Its body always starts with
+          # one of the three headers claude-code-action emits, and always embeds a link to
+          # the run that produced it.
+          gh api graphql --paginate \
+            -F owner="$OWNER" -F name="$NAME" -F pr="$PR" \
+            -f query='
+              query($owner: String!, $name: String!, $pr: Int!, $endCursor: String) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $pr) {
+                    comments(first: 100, after: $endCursor) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes { id isMinimized body author { login } }
+                    }
+                  }
+                }
+              }' \
+            --jq '
+              .data.repository.pullRequest.comments.nodes[]
+              | select(.author.login == "github-actions")
+              | select(.isMinimized | not)
+              | select(.body | test("^\\*\\*Claude (finished|encountered)|^Claude Code is working"))
+              | [ .id, ((.body | [scan("/actions/runs/([0-9]+)")] | flatten | first) // "0") ]
+              | @tsv
+            ' > /tmp/claude-comments.tsv
+
+          while IFS=$'\t' read -r node run; do
+            [ -n "$node" ] || continue
+
+            # Never touch the comment this run just posted.
+            if [ "$run" = "$RUN_ID" ]; then
+              continue
+            fi
+
+            # Preserve answers to @claude questions; only collapse prior push reviews.
+            event=$(gh api "repos/$REPO/actions/runs/$run" --jq '.event' 2>/dev/null || echo "unknown")
+            if [ "$event" != "pull_request" ]; then
+              echo "Keeping comment from run $run (event: $event)"
+              continue
+            fi
+
+            gh api graphql -f query='
+              mutation($id: ID!) {
+                minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+                  minimizedComment { isMinimized }
+                }
+              }' -f id="$node" > /dev/null
+            echo "Collapsed superseded review comment from run $run"
+          done < /tmp/claude-comments.tsv
 
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,12 +40,12 @@ jobs:
 
     steps:
       - name: Checkout code
+        # persist-credentials must stay on. Before reviewing, claude-code-action
+        # runs its own shallow `git fetch origin --depth=20 <branch>`, which relies
+        # on the credential actions/checkout leaves in .git/config. Disabling it
+        # fails with "could not read Username for https://github.com" on any repo
+        # that needs auth to fetch - which is every internal or private fork.
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          # Keep the token out of .git/config: the review step grants Read, so a
-          # persisted credential would be readable by the model. claude-code-action
-          # authenticates git itself from github_token and never uses this one.
-          persist-credentials: false
 
       - name: Skip review (no API key configured)
         if: env.CLAUDE_REVIEW_API_KEY == ''

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,16 +9,25 @@ on:
     types: [created]
 
 # track_progress has every run update the same PR comment, so overlapping runs
-# would race and produce conflicting summaries. Serialize per PR, keeping only
-# the newest run - an in-flight review is stale once a new push or @claude lands.
+# would race and produce conflicting summaries. Serialize per PR.
+# Only a new push supersedes a running review; a comment-triggered run waits its
+# turn instead, so an @claude request never cancels a review already underway.
 concurrency:
   group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   claude-review:
-    # issue_comment fires on plain issues too, not just PRs - skip those
-    if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
+    # Comment triggers are narrowed to human @claude mentions on a pull request.
+    # Bot comments (CodeRabbit, Bugbot) would otherwise start a run that the action
+    # rejects outright with "Workflow initiated by non-human actor", and that run
+    # would also contend with the review it just interrupted.
+    if: >-
+      github.event_name == 'pull_request' ||
+      (github.event.comment.user.type != 'Bot' &&
+       contains(github.event.comment.body, '@claude') &&
+       (github.event_name == 'pull_request_review_comment' ||
+        github.event.issue.pull_request != null))
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,54 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude-review:
+    # issue_comment fires on plain issues too, not just PRs - skip those
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@ba0aafd4308cbba7165f9f2cdb0cfbed5a3c99ce # v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_REVIEW }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          trigger_phrase: "@claude"
+          track_progress: true
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 50
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Read,Grep,Glob"
+          prompt: |
+            Review this PR. Focus on issues that need fixing:
+
+            - Security vulnerabilities (hardcoded secrets, SQL injection, XSS)
+            - TDD violations (implementation without tests - see CLAUDE.md)
+            - CLAUDE.md pattern violations (public controllers, missing @InitBinder, Optional.get())
+            - Critical bugs or logic errors
+
+            **IMPORTANT**: Skip all files in the docs/specs/ folder - do not read or review them.
+
+            Use inline comments for specific issues.
+
+            **MANDATORY**: Before finishing, update the tracked progress comment with a summary that includes:
+            - A brief overview of the changes reviewed
+            - Any issues found (or state that no issues were found)
+            - A final verdict: LGTM or Changes Requested
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,6 +41,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Keep the token out of .git/config: the review step grants Read, so a
+          # persisted credential would be readable by the model. claude-code-action
+          # authenticates git itself from github_token and never uses this one.
+          persist-credentials: false
 
       - name: Skip review (no API key configured)
         if: env.CLAUDE_REVIEW_API_KEY == ''
@@ -51,7 +56,7 @@ jobs:
 
       - name: Claude Code Review
         if: env.CLAUDE_REVIEW_API_KEY != ''
-        uses: anthropics/claude-code-action@ba0aafd4308cbba7165f9f2cdb0cfbed5a3c99ce # v1
+        uses: anthropics/claude-code-action@37b464ce72700f7b2c5ff8d2db7fa7b15df792f5 # v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_REVIEW }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,6 +8,13 @@ on:
   pull_request_review_comment:
     types: [created]
 
+# track_progress has every run update the same PR comment, so overlapping runs
+# would race and produce conflicting summaries. Serialize per PR, keeping only
+# the newest run - an in-flight review is stale once a new push or @claude lands.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # issue_comment fires on plain issues too, not just PRs - skip those

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -65,6 +65,10 @@ jobs:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_REVIEW }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "@claude"
+          # Every run posts its own tracking comment, so a PR collects one per push.
+          # use_sticky_comment does not help while we authenticate with GITHUB_TOKEN:
+          # it only reuses a comment authored by claude[bot] (id 209825114), and ours
+          # come from github-actions[bot]. Collapsing them needs the Claude GitHub App.
           track_progress: true
           claude_args: |
             --model claude-sonnet-5

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,11 +15,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
+    # Bound to a job-level env var so the review step can be gated on it below.
+    # The `secrets` context is unavailable in job-level `if`, but `env` works at step level.
+    env:
+      CLAUDE_REVIEW_API_KEY: ${{ secrets.CLAUDE_CODE_REVIEW }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Skip review (no API key configured)
+        if: env.CLAUDE_REVIEW_API_KEY == ''
+        run: |
+          echo "::notice::CLAUDE_CODE_REVIEW secret is not available - skipping Claude review."
+          echo "This is expected on repositories that have not configured the secret, and on"
+          echo "pull requests from forks (GitHub withholds secrets from fork-triggered runs)."
+
       - name: Claude Code Review
+        if: env.CLAUDE_REVIEW_API_KEY != ''
         uses: anthropics/claude-code-action@ba0aafd4308cbba7165f9f2cdb0cfbed5a3c99ce # v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_CODE_REVIEW }}


### PR DESCRIPTION
## Summary
Adds `.github/workflows/claude-code-review.yml`, an automated Claude Code review that runs on PRs and on human `@claude` mentions in PR comments.

The review focuses on security vulnerabilities, TDD violations, CLAUDE.md pattern violations (public controllers, missing `@InitBinder`, `Optional.get()`), and critical bugs/logic errors. It skips `docs/specs/`, posts inline comments, and updates a tracked progress comment with a final LGTM / Changes Requested verdict.

## Why this lives here
Per the Forge setup docs, participants run `gh repo fork liatrio-labs/emerald-grove-pet-clinic --org liatrio-forge`. Forking copies `.github/workflows/` at fork time, so shipping the workflow here is what makes it available in every participant's Forge repo. The `liatrio-forge` org provides the `CLAUDE_CODE_REVIEW` secret.

## This workflow is a no-op in this repo, by design
This repo has no `CLAUDE_CODE_REVIEW` secret and shouldn't get one — we don't want Claude reviewing PRs against the upstream example repo. The review step is gated on the secret being present, so the job logs a notice and succeeds as a no-op here. It activates on its own in any Forge repo where the org secret is reachable.

This also covers a freshly-forked repo before the participant sets `--visibility internal`, and PRs from forks (which GitHub never grants secrets). Both previously produced a hard failure; see #42.

## Verified end-to-end
Tested in a throwaway Forge-style fork (`liatrio-forge/emerald-grove-pet-clinic-workflow-test`) with the org secret reachable, against a PR that deliberately introduced an unguarded `Optional.get()` and shipped production code without a test:

- The `pull_request` run posted an inline comment on the offending line with a suggested `Optional<Specialty>` fix, flagged the missing test, and returned **Changes Requested**.
- A human `@claude` question on the PR triggered exactly one run and got a correct, substantive answer.
- Three bot comments (CodeRabbit, and the action's own progress comment) triggered **zero** runs.

That testing surfaced two bugs, both fixed here:

**1. Bot comments produced failed runs.** `claude-code-action` rejects them outright with `Workflow initiated by non-human actor: coderabbitai (type: Bot)`. Every CodeRabbit or Bugbot comment — and the action's own tracked progress comment — spawned a run that failed. This reproduces on the existing downstream copy of this workflow, where `issue_comment` runs have failed 4-for-4.

**2. Those runs cancelled the review in flight.** `issue_comment` and `pull_request` events resolve to the same concurrency group (`issue.number` == `pull_request.number`), so with `cancel-in-progress: true` a bot comment killed the running review ~10s after it started.

Both are fixed by not starting a run for comments the workflow has no business reacting to:

```yaml
concurrency:
  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}

if: >-
  github.event_name == 'pull_request' ||
  (github.event.comment.user.type != 'Bot' &&
   contains(github.event.comment.body, '@claude') && ...)
```

Only a new push supersedes a running review; a comment-triggered run waits its turn instead.

Supersedes #42, which was opened from a personal fork and hit GitHub's fork-PR secret restrictions.

## Test plan
- [x] YAML parses; step guards resolve for all three triggers
- [x] `claude-review` passes (as a skip) on this PR, since this repo has no secret
- [x] A Forge repo with the org secret runs the full review, posts inline comments, and returns a verdict
- [x] Human `@claude` comment triggers a run; bot comments do not
- [x] A bot comment no longer cancels an in-flight review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated code review check for pull requests and `@claude`-triggered review comments.
  * Review results are posted back to the PR with a progress update, findings, and a final recommendation.

* **Chores**
  * Prevents duplicate review runs on the same PR or issue and skips reviews when required credentials aren’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow with no application runtime changes; main risk is misconfigured triggers or token permissions affecting PR comments, not production code.
> 
> **Overview**
> Adds **`.github/workflows/claude-code-review.yml`**, a GitHub Actions job that runs **Claude Code** on pull requests and on human **`@claude`** mentions in PR/issue comments.
> 
> **Triggers and gating:** Runs on PR open/sync/ready/reopen and comment events, but **skips bot comments** and only reacts to **`@claude`** on PR threads. **Concurrency** is per PR: new pushes **cancel** an in-flight review; comment-triggered runs **queue** instead of cancelling. The review step runs only when **`CLAUDE_CODE_REVIEW`** is set; otherwise the job logs a notice and exits successfully (upstream / fork PRs without secrets).
> 
> **Review behavior:** Uses **`anthropics/claude-code-action`** with a focused prompt (security, TDD, **CLAUDE.md** patterns, critical bugs; skips **`docs/specs/`**), inline comments, and a tracked progress comment ending in **LGTM** or **Changes Requested**.
> 
> **Cleanup:** After push-triggered reviews, a GraphQL step **minimizes** older **`github-actions`** tracking comments from prior **`pull_request`** runs (keeps **`@claude`** answer threads and the current run’s comment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a9c55bb88f01cee1623e8e90a6daf3eee381af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->