### PR TITLE
feat: add PR description template and validation workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+  Structure adapted from the `create-pull-request` skill in liatrio-labs/ai-prompts:
+  https://github.com/liatrio-labs/ai-prompts/tree/main/skills/create-pull-request
+
+  This is intentionally a starting point, not a mandate. Every project and every
+  team will want something a little different here — trim, extend, or replace
+  these sections to match how your reviewers actually read PRs.
+-->
+
+## Why?
+
+<!-- TEMPLATE:WHY - Explain the motivation and context for these changes. What problem does this solve? -->
+
+## What Changed?
+
+<!-- TEMPLATE:WHAT-CHANGED - Summarize the changes. Focus on outcomes and behavior, not low-level implementation detail. -->
+
+### Key Changes
+
+-
+
+**Files Modified:**
+
+## Additional Notes
+
+- **Breaking Changes:**
+- **Testing Strategy:**
+- **Configuration Changes:**
+- **Known Limitations:**
+- **Related Issues:**
+
+## Review Checklist
+
+- [ ] Code follows project style guidelines
+- [ ] Self-review completed
+- [ ] Tests added/updated for new functionality (TDD: RED-GREEN-REFACTOR)
+- [ ] Documentation updated if needed
+- [ ] No breaking changes (or migration path documented)

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,91 @@
+# Validates PR descriptions against .github/PULL_REQUEST_TEMPLATE.md.
+#
+# The template structure is adapted from the `create-pull-request` skill in
+# liatrio-labs/ai-prompts:
+# https://github.com/liatrio-labs/ai-prompts/tree/main/skills/create-pull-request
+#
+# A template file on its own enforces nothing — GitHub pre-fills the description
+# box, but any author (human or AI agent) can delete it or bypass it entirely
+# with `gh pr create --body`. This workflow is the part that actually checks the
+# description was filled in. To make it binding, add "check-template" as a
+# required status check in the branch protection rules for `main`.
+#
+# Treat the required sections below as a starting point and tune them to taste.
+name: PR Template Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-template:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Validate PR description against template
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+
+            const REQUIRED_HEADERS = [
+              '## Why?',
+              '## What Changed?',
+              '## Additional Notes',
+              '## Review Checklist',
+            ];
+
+            const PLACEHOLDER_MARKERS = [
+              '<!-- TEMPLATE:WHY',
+              '<!-- TEMPLATE:WHAT-CHANGED',
+            ];
+
+            const errors = [];
+
+            for (const header of REQUIRED_HEADERS) {
+              if (!body.includes(header)) {
+                errors.push(`Missing required section: "${header}"`);
+              }
+            }
+
+            for (const marker of PLACEHOLDER_MARKERS) {
+              if (body.includes(marker)) {
+                errors.push(
+                  `Placeholder guidance text was not replaced (found "${marker}"). ` +
+                  `Fill in that section with real content.`
+                );
+              }
+            }
+
+            // Extract the text of a section: everything between its header and the next "## " header.
+            function sectionBody(markdown, header) {
+              const startIdx = markdown.indexOf(header);
+              if (startIdx === -1) return '';
+              const afterHeader = markdown.slice(startIdx + header.length);
+              const nextHeaderIdx = afterHeader.search(/\n##\s/);
+              const raw = nextHeaderIdx === -1 ? afterHeader : afterHeader.slice(0, nextHeaderIdx);
+              return raw.replace(/<!--[\s\S]*?-->/g, '').trim();
+            }
+
+            const MIN_SECTION_LENGTH = 10;
+            for (const header of ['## Why?', '## What Changed?']) {
+              const text = sectionBody(body, header);
+              if (text.length < MIN_SECTION_LENGTH) {
+                errors.push(`Section "${header}" needs real content (currently empty or too short).`);
+              }
+            }
+
+            if (errors.length > 0) {
+              core.setFailed(
+                'PR description does not satisfy PULL_REQUEST_TEMPLATE.md:\n' +
+                errors.map((e) => `  - ${e}`).join('\n') +
+                '\n\nEdit the PR description to fill in the template sections, then re-run this check.'
+              );
+            } else {
+              core.info('PR description satisfies the required template sections.');
+            }
+
+    permissions:
+      contents: read
+      pull-requests: read

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -51,10 +51,19 @@ jobs:
               .replace(/<!--[\s\S]*?-->/g, '')
               .replace(/<!--[\s\S]*$/, '');
 
+            // Match a heading only as its own line. A substring match would let
+            // "...instead of a ## Why? heading..." satisfy the presence check without the
+            // section ever existing. Headers contain regex metacharacters ("?"), so escape
+            // them; trailing whitespace after a heading is tolerated.
+            function headingPattern(header) {
+              const escaped = header.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              return new RegExp('^' + escaped + '[ \\t]*$', 'm');
+            }
+
             const errors = [];
 
             for (const header of REQUIRED_HEADERS) {
-              if (!visible.includes(header)) {
+              if (!headingPattern(header).test(visible)) {
                 errors.push(`Missing required section: "${header}"`);
               }
             }
@@ -68,13 +77,14 @@ jobs:
               }
             }
 
-            // Extract a section: everything between its header and the next "## " header.
-            // Operates on comment-stripped markdown so commented-out "## " lines cannot
-            // truncate a section early.
+            // Extract a section: everything between its heading line and the next "## "
+            // heading. Operates on comment-stripped markdown so commented-out "## " lines
+            // cannot truncate a section early, and anchors the start on the same pattern
+            // used for the presence check so the two cannot disagree.
             function sectionBody(markdown, header) {
-              const startIdx = markdown.indexOf(header);
-              if (startIdx === -1) return '';
-              const afterHeader = markdown.slice(startIdx + header.length);
+              const match = markdown.match(headingPattern(header));
+              if (!match) return '';
+              const afterHeader = markdown.slice(match.index + match[0].length);
               const nextHeaderIdx = afterHeader.search(/\n##\s/);
               return (nextHeaderIdx === -1 ? afterHeader : afterHeader.slice(0, nextHeaderIdx)).trim();
             }

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -41,10 +41,20 @@ jobs:
               '<!-- TEMPLATE:WHAT-CHANGED',
             ];
 
+            // Strip HTML comments up front. A "## " line inside a comment must not be
+            // mistaken for a real section heading, and a heading commented out must not
+            // count as present. Placeholder detection deliberately runs on the raw body,
+            // because the markers themselves are comments.
+            // Unterminated comments are dropped through end-of-body so a stray "<!--"
+            // cannot leak into a section and be counted as content.
+            const visible = body
+              .replace(/<!--[\s\S]*?-->/g, '')
+              .replace(/<!--[\s\S]*$/, '');
+
             const errors = [];
 
             for (const header of REQUIRED_HEADERS) {
-              if (!body.includes(header)) {
+              if (!visible.includes(header)) {
                 errors.push(`Missing required section: "${header}"`);
               }
             }
@@ -58,19 +68,20 @@ jobs:
               }
             }
 
-            // Extract the text of a section: everything between its header and the next "## " header.
+            // Extract a section: everything between its header and the next "## " header.
+            // Operates on comment-stripped markdown so commented-out "## " lines cannot
+            // truncate a section early.
             function sectionBody(markdown, header) {
               const startIdx = markdown.indexOf(header);
               if (startIdx === -1) return '';
               const afterHeader = markdown.slice(startIdx + header.length);
               const nextHeaderIdx = afterHeader.search(/\n##\s/);
-              const raw = nextHeaderIdx === -1 ? afterHeader : afterHeader.slice(0, nextHeaderIdx);
-              return raw.replace(/<!--[\s\S]*?-->/g, '').trim();
+              return (nextHeaderIdx === -1 ? afterHeader : afterHeader.slice(0, nextHeaderIdx)).trim();
             }
 
             const MIN_SECTION_LENGTH = 10;
             for (const header of ['## Why?', '## What Changed?']) {
-              const text = sectionBody(body, header);
+              const text = sectionBody(visible, header);
               if (text.length < MIN_SECTION_LENGTH) {
                 errors.push(`Section "${header}" needs real content (currently empty or too short).`);
               }

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -51,6 +51,20 @@ jobs:
               .replace(/<!--[\s\S]*?-->/g, '')
               .replace(/<!--[\s\S]*$/, '');
 
+            // Blank out fenced code blocks for structural scanning. A "## " line inside a
+            // fence is example text, not a heading: without this, pasting the whole template
+            // into one fence passes every rule with no real sections, and a fence inside a
+            // real section ends it early.
+            //
+            // Every masked character is replaced with a space and newlines are kept, so
+            // offsets into `structure` map exactly onto `visible`. Headings and boundaries
+            // are located in `structure`; the text at those offsets is then read back out of
+            // `visible`, so a section whose content is a legitimate code block still counts.
+            const structure = visible.replace(
+              /^([ \t]*)(```|~~~)[\s\S]*?^\1?\2[ \t]*$/gm,
+              (block) => block.replace(/[^\n]/g, ' ')
+            );
+
             // Match a heading only as its own line. A substring match would let
             // "...instead of a ## Why? heading..." satisfy the presence check without the
             // section ever existing. Headers contain regex metacharacters ("?"), so escape
@@ -63,7 +77,7 @@ jobs:
             const errors = [];
 
             for (const header of REQUIRED_HEADERS) {
-              if (!headingPattern(header).test(visible)) {
+              if (!headingPattern(header).test(structure)) {
                 errors.push(`Missing required section: "${header}"`);
               }
             }
@@ -78,20 +92,22 @@ jobs:
             }
 
             // Extract a section: everything between its heading line and the next "## "
-            // heading. Operates on comment-stripped markdown so commented-out "## " lines
-            // cannot truncate a section early, and anchors the start on the same pattern
-            // used for the presence check so the two cannot disagree.
-            function sectionBody(markdown, header) {
-              const match = markdown.match(headingPattern(header));
+            // heading. Boundaries are found in `structure` (comments and fences masked) and
+            // the content is sliced from `visible` at those same offsets. The presence check
+            // above shares `headingPattern`, so the two cannot disagree on where a section
+            // begins.
+            function sectionBody(header) {
+              const match = structure.match(headingPattern(header));
               if (!match) return '';
-              const afterHeader = markdown.slice(match.index + match[0].length);
-              const nextHeaderIdx = afterHeader.search(/\n##\s/);
-              return (nextHeaderIdx === -1 ? afterHeader : afterHeader.slice(0, nextHeaderIdx)).trim();
+              const start = match.index + match[0].length;
+              const nextHeaderIdx = structure.slice(start).search(/\n##\s/);
+              const end = nextHeaderIdx === -1 ? visible.length : start + nextHeaderIdx;
+              return visible.slice(start, end).trim();
             }
 
             const MIN_SECTION_LENGTH = 10;
             for (const header of ['## Why?', '## What Changed?']) {
-              const text = sectionBody(visible, header);
+              const text = sectionBody(header);
               if (text.length < MIN_SECTION_LENGTH) {
                 errors.push(`Section "${header}" needs real content (currently empty or too short).`);
               }


### PR DESCRIPTION
<!--
  Structure adapted from the `create-pull-request` skill in liatrio-labs/ai-prompts:
  https://github.com/liatrio-labs/ai-prompts/tree/main/skills/create-pull-request
-->

## Why?

This repo has no PR description template, so PR bodies are freeform and reviewers get inconsistent context.

The broader point: **a template file by itself enforces nothing.** GitHub pre-fills the description box from `PULL_REQUEST_TEMPLATE.md`, but any author can delete it, and `gh pr create --body "..."` bypasses it entirely. There is no native GitHub setting that blocks a PR for "not using the template." That gap matters more as AI agents open PRs — an agent following a bad prompt will happily submit an empty description, and instructions in `CLAUDE.md` are a convention, not a gate.

So this PR adds both halves: the template, and a CI check that actually validates it.

**Evidence:** Template structure is adapted from the `create-pull-request` skill in [liatrio-labs/ai-prompts](https://github.com/liatrio-labs/ai-prompts/tree/main/skills/create-pull-request), which defines the Why? / What Changed? / Additional Notes / Review Checklist sections used here.

## What Changed?

Added a PR description template and a GitHub Actions workflow that validates PR bodies against it.

### Key Changes

- **`.github/PULL_REQUEST_TEMPLATE.md`** — Why? / What Changed? / Additional Notes / Review Checklist sections, with `<!-- TEMPLATE:* -->` comment markers in the two prose sections so CI can distinguish "guidance text never replaced" from "section left empty."
- **`.github/workflows/pr-template-check.yml`** — runs on PR `opened`/`edited`/`synchronize`/`reopened` and fails when any required header is missing, a `TEMPLATE:*` placeholder marker survives, or Why? / What Changed? are effectively empty after stripping HTML comments.
- Both files carry a header comment pointing back to the `ai-prompts` source and noting the template is a starting point, not a mandate.

**Files Modified:** `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/pr-template-check.yml`

## Additional Notes

- **Breaking Changes:** None.
- **Testing Strategy:** The validation script is extracted directly out of the workflow YAML and exercised against a 15-case matrix, so the tests run the shipped code rather than a hand-copied duplicate. Coverage includes the raw template (correctly reports 3 errors), a filled body, code-fence bypass and truncation in both backtick and tilde form, indented fences nested in lists, headings appearing only mid-sentence or inside backticks, HTML-commented headings, unterminated comments, CRLF bodies, trailing whitespace after headings, and a genuinely empty section. It was also verified end-to-end on a fork: a PR opened with the unfilled template **failed** the check, and editing the body to real content flipped the same check to **success** on the `edited` event. This PR's own description is a live pass case.
- **Configuration Changes:** None required. The workflow is **not** wired into branch protection, so today it reports without blocking. To make it binding, add `check-template` as a required status check on `main`.
- **Known Limitations:** The `MIN_SECTION_LENGTH = 10` heuristic catches empty and near-empty sections, not low-effort ones — `"fixed stuff"` passes. Required headers are matched by exact string, so renaming a heading in the template means updating `REQUIRED_HEADERS` in the workflow to match. HTML comments (`d7df977`) and fenced code blocks (`f21d63c`) are masked before structural scanning, and headings must appear on their own line (`c00bc89`), so none of those can spoof or truncate a section.
- **Related Issues:** N/A

## Review Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated for new functionality (TDD: RED-GREEN-REFACTOR)
- [x] Documentation updated if needed
- [x] No breaking changes (or migration path documented)

---

### A note on adopting this

Every project and every reviewer wants something different out of a PR description. This is deliberately boilerplate — a solid default for a repo that has nothing set up today, not a house style anyone needs to inherit. Trim the sections, loosen the check, or drop `pr-template-check.yml` and keep only the template. The one idea worth carrying over is the split: **the template communicates intent, the required status check is what actually enforces it.**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.github` template and workflow metadata; no runtime, auth, or data-path changes unless branch protection is later configured to require the check.
> 
> **Overview**
> Introduces a **standard PR description template** and a **GitHub Actions check** so PR bodies stay structured instead of freeform.
> 
> **`.github/PULL_REQUEST_TEMPLATE.md`** adds Why?, What Changed?, Additional Notes, and Review Checklist, with `<!-- TEMPLATE:* -->` markers in the two narrative sections for CI to detect unfilled guidance.
> 
> **`.github/workflows/pr-template-check.yml`** runs on PR open/edit/sync/reopen and fails when required `##` headings are missing, placeholder markers remain, or Why? / What Changed? are too short after stripping HTML comments. Branch protection can require the `check-template` job to make it blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00bc89ec130acc89684466ee9765904f0ff4613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


