### PR TITLE
ci: add Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,182 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+# track_progress has every run update the same PR comment, so overlapping runs
+# would race and produce conflicting summaries. Serialize per PR.
+# A pull_request event supersedes a running review, since any of its action types
+# (opened, synchronize, ready_for_review, reopened) leaves an in-flight review
+# stale. A comment-triggered run waits its turn instead, so an @claude request
+# never cancels a review already underway.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  claude-review:
+    # Comment triggers are narrowed to human @claude mentions on a pull request.
+    # Bot comments (CodeRabbit, Bugbot) would otherwise start a run that the action
+    # rejects outright with "Workflow initiated by non-human actor", and that run
+    # would also contend with the review it just interrupted.
+    if: >-
+      github.event_name == 'pull_request' ||
+      (github.event.comment.user.type != 'Bot' &&
+       contains(github.event.comment.body, '@claude') &&
+       (github.event_name == 'pull_request_review_comment' ||
+        github.event.issue.pull_request != null))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    # Bound to a job-level env var so the review step can be gated on it below.
+    # The `secrets` context is unavailable in job-level `if`, but `env` works at step level.
+    env:
+      CLAUDE_REVIEW_API_KEY: ${{ secrets.CLAUDE_CODE_REVIEW }}
+
+    steps:
+      - name: Checkout code
+        # persist-credentials must stay on. Before reviewing, claude-code-action
+        # runs its own shallow `git fetch origin --depth=20 <branch>`, which relies
+        # on the credential actions/checkout leaves in .git/config. Disabling it
+        # fails with "could not read Username for https://github.com" on any repo
+        # that needs auth to fetch - which is every internal or private fork.
+        #
+        # Disabling it would not harden anything either: configureGitAuth then
+        # writes the token straight back via `git remote set-url origin
+        # https://x-access-token:$TOKEN@...` before the model ever runs.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Skip review (no API key configured)
+        if: env.CLAUDE_REVIEW_API_KEY == ''
+        run: |
+          echo "::notice::CLAUDE_CODE_REVIEW secret is not available - skipping Claude review."
+          echo "This is expected on repositories that have not configured the secret, and on"
+          echo "pull requests from forks (GitHub withholds secrets from fork-triggered runs)."
+
+      - name: Claude Code Review
+        if: env.CLAUDE_REVIEW_API_KEY != ''
+        uses: anthropics/claude-code-action@37b464ce72700f7b2c5ff8d2db7fa7b15df792f5 # v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_REVIEW }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          trigger_phrase: "@claude"
+          # Each run posts its own tracking comment. use_sticky_comment cannot collapse
+          # them while we authenticate with GITHUB_TOKEN: it only reuses a comment whose
+          # author is claude[bot] (id 209825114), and ours come from github-actions[bot].
+          # The "Collapse superseded review comments" step below handles it instead.
+          track_progress: true
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 50
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Read,Grep,Glob"
+          prompt: |
+            Review this PR. Focus on issues that need fixing:
+
+            - Security vulnerabilities (hardcoded secrets, SQL injection, XSS)
+            - TDD violations (implementation without tests - see CLAUDE.md)
+            - CLAUDE.md pattern violations (public controllers, missing @InitBinder, Optional.get())
+            - Critical bugs or logic errors
+
+            **IMPORTANT**: Skip all files in the docs/specs/ folder - do not read or review them.
+
+            Use inline comments for specific issues.
+
+            **MANDATORY**: Before finishing, update the tracked progress comment with a summary that includes:
+            - A brief overview of the changes reviewed
+            - Any issues found (or state that no issues were found)
+            - A final verdict: LGTM or Changes Requested
+
+      # Runs after the review so a cancelled or failed run never destroys the only
+      # summary on the PR. Collapses rather than deletes: permalinks, reactions and
+      # the record of what Claude said about an earlier push all survive.
+      #
+      # Only push-triggered reviews supersede one another. A comment-triggered run is
+      # answering a question, so its comment is a conversation turn and is left alone -
+      # identified by looking up the event of the run that produced each comment.
+      #
+      # A run cancelled by cancel-in-progress can leave an orphaned "Claude Code is
+      # working..." comment behind. That body is matched too, so the next push sweeps it.
+      - name: Collapse superseded review comments
+        if: always() && env.CLAUDE_REVIEW_API_KEY != '' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          NAME: ${{ github.event.repository.name }}
+          PR: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Collapsing is housekeeping: the review itself has already posted its verdict
+          # by the time this step runs. A transient GitHub API failure here must never
+          # turn a successful review red, so both API calls below tolerate failure and
+          # warn instead. set -e still guards genuine script errors.
+          #
+          # github-actions[bot] authors the tracking comment. Its body always starts with
+          # one of the three headers claude-code-action emits, and always embeds a link to
+          # the run that produced it.
+          if ! gh api graphql --paginate \
+            -F owner="$OWNER" -F name="$NAME" -F pr="$PR" \
+            -f query='
+              query($owner: String!, $name: String!, $pr: Int!, $endCursor: String) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $pr) {
+                    comments(first: 100, after: $endCursor) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes { id isMinimized body author { login } }
+                    }
+                  }
+                }
+              }' \
+            --jq '
+              .data.repository.pullRequest.comments.nodes[]
+              | select(.author.login == "github-actions")
+              | select(.isMinimized | not)
+              | select(.body | test("^\\*\\*Claude (finished|encountered)|^Claude Code is working"))
+              | [ .id, ((.body | [scan("/actions/runs/([0-9]+)")] | flatten | first) // "0") ]
+              | @tsv
+            ' > /tmp/claude-comments.tsv; then
+            echo "::warning::Could not list PR comments; skipping collapse of superseded reviews."
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r node run; do
+            [ -n "$node" ] || continue
+
+            # Never touch the comment this run just posted.
+            if [ "$run" = "$RUN_ID" ]; then
+              continue
+            fi
+
+            # Preserve answers to @claude questions; only collapse prior push reviews.
+            event=$(gh api "repos/$REPO/actions/runs/$run" --jq '.event' 2>/dev/null || echo "unknown")
+            if [ "$event" != "pull_request" ]; then
+              echo "Keeping comment from run $run (event: $event)"
+              continue
+            fi
+
+            # A comment deleted between the fetch above and this mutation fails here.
+            # Warn and move on rather than abandoning the comments still to collapse.
+            if gh api graphql -f query='
+              mutation($id: ID!) {
+                minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+                  minimizedComment { isMinimized }
+                }
+              }' -f id="$node" > /dev/null; then
+              echo "Collapsed superseded review comment from run $run"
+            else
+              echo "::warning::Could not collapse superseded review comment from run $run."
+            fi
+          done < /tmp/claude-comments.tsv
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read


### PR DESCRIPTION
## Summary

Adds `.github/workflows/claude-code-review.yml` so that every fork of this repository gets Claude reviewing its pull requests from the first PR, with nothing for the participant to set up.

This repo is the starting point for everyone going through the Forge program. Today a participant who wants AI review on their work has to go find a workflow, adapt it, and wire up credentials before they see any benefit — which most won't do, and none should have to. Putting the workflow here means it arrives with the fork.

The API key arrives the same way: `CLAUDE_CODE_REVIEW` is an organization secret, inherited by forks under the org, so a participant never handles a credential. Fork, open a PR, get a review.

## What the reviewer does

Claude reviews every pull request on push, and answers `@claude` mentions in PR comments. The prompt targets the things this codebase actually cares about — security issues, TDD violations, `CLAUDE.md` pattern violations, and logic errors — and posts findings as inline comments, with a `LGTM` / `Changes Requested` verdict in a tracked summary comment.

## When no key is available

The review step is gated on the `CLAUDE_CODE_REVIEW` secret. Where it is absent — a fork outside the org, or a pull request opened from a fork, since GitHub withholds secrets from fork-triggered runs — the job emits a `::notice::` explaining why and skips. It does not fail, and it never blocks a PR. A participant working outside the org sees a clean skip, not a broken pipeline they have to debug.

This also means the workflow is safe to merge before any key is in place.

## Design decisions

Each of these came out of a real failure, and the reasoning is preserved in comments in the workflow itself:

- **`concurrency` group per PR** — `track_progress` has every run update the same PR comment, so overlapping runs race and produce conflicting summaries. Push events supersede an in-flight review (`cancel-in-progress`); comment-triggered runs queue instead, so an `@claude` question never cancels a review already underway.
- **Bot comments filtered out** — CodeRabbit and Bugbot comments would otherwise start a run that `claude-code-action` rejects with "Workflow initiated by non-human actor", after cancelling the review it just interrupted.
- **`persist-credentials` left enabled** — `claude-code-action` runs its own `git fetch origin --depth=20 <branch>` and relies on the credential `actions/checkout` leaves behind. Disabling it fails with "could not read Username for https://github.com" on any repo that needs auth to fetch. It would harden nothing either: the action writes the token straight back into the remote URL before the model ever runs.
- **Superseded reviews are collapsed, not deleted** — minimized as `OUTDATED`, preserving permalinks, reactions, and the record of what Claude said about an earlier push. The step runs `always()` so a cancelled or failed run never destroys the only summary on the PR, and it tolerates API failure with a warning rather than turning a green review red.

Actions are pinned to commit SHAs.

## Test plan

- [x] Confirm the `CLAUDE_CODE_REVIEW` org secret grants access to this repository and to newly created forks
- [x] Fork the repo as a participant would, open a PR, and confirm Claude reviews it with no additional setup
- [x] Push a second commit to that PR and confirm the prior review comment collapses as outdated
- [x] Comment `@claude` on the PR and confirm it responds without collapsing the existing review
- [x] Confirm a PR opened from a fork outside the org skips cleanly with a notice rather than failing
- Test PR can be seen here: https://github.com/liatrio-forge/emerald-grove-pet-clinic-workflow-test/pull/3

The workflow ran against this PR and took the skip path, since this repository has no key configured yet — the expected pre-merge state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
