### PR TITLE
fix: resolve markdownlint violations in spec docs

### DIFF
--- a/docs/specs/01-spec-performance-testing-ci/01-proofs/01-task-1-proofs.md
+++ b/docs/specs/01-spec-performance-testing-ci/01-proofs/01-task-1-proofs.md
@@ -14,7 +14,7 @@ Task 1.0 adds a `performance` Maven profile to `pom.xml` that:
 
 Command run against a locally running Spring Boot app (H2 profile, port 8080).
 
-```
+```text
 [INFO] --- jmeter:3.8.0:results (jmeter-check-results) @ spring-petclinic ---
 [INFO] Result (.csv) files scanned: 1
 [INFO] Successful requests:         75020
@@ -51,7 +51,7 @@ Parsing: target/jmeter/results/20260330-petclinic_test_plan.csv
 Throughput threshold temporarily raised to 99999 req/s (an impossible value) and script run
 directly against the real JTL results:
 
-```
+```console
 $ src/test/jmeter/check-thresholds.sh target/jmeter/results
 
 Parsing: target/jmeter/results/20260330-petclinic_test_plan.csv

--- a/docs/specs/01-spec-performance-testing-ci/01-proofs/01-task-2-proofs.md
+++ b/docs/specs/01-spec-performance-testing-ci/01-proofs/01-task-2-proofs.md
@@ -17,7 +17,7 @@ Task 2.0 adds `.github/workflows/performance-tests.yml` that:
 
 GitHub Actions run: https://github.com/liatrio-labs/emerald-grove-pet-clinic/actions/runs/23765780620
 
-```
+```text
 ✓ jmeter in 4m3s (ID 69244741912)
   ✓ Set up job
   ✓ Checkout
@@ -41,7 +41,7 @@ GitHub Actions run: https://github.com/liatrio-labs/emerald-grove-pet-clinic/act
 The following output was captured directly from the "Run performance tests" step log
 (run 23765780620), demonstrating results are visible without downloading an artifact:
 
-```
+```text
          JMeter Performance Threshold Summary
 ------------------------------------------------------------
   Total samples : 15727
@@ -77,7 +77,7 @@ First CI run (23765114432) used the original test plan (500 threads, loop-based)
 The CI runner was saturated, producing avg 3333ms and p95 5619ms — both above the
 500ms/1000ms thresholds. The `check-thresholds.sh` script correctly failed the build:
 
-```
+```text
          JMeter Performance Threshold Summary
 ------------------------------------------------------------
   Total samples : 75008

--- a/docs/specs/01-spec-performance-testing-ci/01-validation-performance-testing-ci.md
+++ b/docs/specs/01-spec-performance-testing-ci/01-validation-performance-testing-ci.md
@@ -113,7 +113,7 @@
 
 ### Threshold Configuration Verified
 
-```
+```text
 check-thresholds.sh:15-18
   AVG_THRESHOLD_MS=500
   P95_THRESHOLD_MS=1000
@@ -123,7 +123,7 @@ check-thresholds.sh:15-18
 
 ### JMX Configuration Verified
 
-```
+```text
 petclinic_test_plan.jmx
   ThreadGroup.num_threads = 50       (was 500)
   LoopController.continue_forever = true

--- a/docs/specs/02-spec-no-direct-commits-to-main/validation-report.md
+++ b/docs/specs/02-spec-no-direct-commits-to-main/validation-report.md
@@ -33,7 +33,7 @@
 
 ## Unit 1: Pre-commit Hook Implementation
 
-### Functional Requirements
+### Functional Requirements (Unit 1)
 
 | # | Requirement | Status | Evidence |
 |---|---|---|---|
@@ -44,9 +44,9 @@
 | 1.5 | Hook handles detached HEAD gracefully (allows commit) | PASS | Test script: "Hook exits 0 in detached HEAD state" + "Hook produces no error output in detached HEAD" |
 | 1.6 | Hook has `always_run: true` and `pass_filenames: false` | PASS | `.pre-commit-config.yaml:88-89` confirmed; test script also validates these fields |
 | 1.7 | Hook uses `language: system` | PASS | `.pre-commit-config.yaml:87` confirmed; test script validates this field |
-| 1.8 | Hook entry in existing `repo: local` section alongside maven-compile-check | PASS | `.pre-commit-config.yaml:69-90` -- both hooks under same `repo: local` block |
+| 1.8 | Hook entry in existing `repo: local` section alongside Maven-compile-check | PASS | `.pre-commit-config.yaml:69-90` -- both hooks under same `repo: local` block |
 
-### Proof Artifacts
+### Proof Artifacts (Unit 1)
 
 | # | Artifact | Status | Evidence |
 |---|---|---|---|
@@ -58,7 +58,7 @@
 
 ## Unit 2: Documentation Update
 
-### Functional Requirements
+### Functional Requirements (Unit 2)
 
 | # | Requirement | Status | Evidence |
 |---|---|---|---|
@@ -67,7 +67,7 @@
 | 2.3 | Documentation notes `--no-verify` can bypass in exceptional cases | PASS | `docs/PRECOMMIT.md:167-173` -- documents `--no-verify` flag with code example |
 | 2.4 | Consistent with existing documentation style and formatting | PASS | Uses same heading hierarchy, code blocks, bold labels, and prose style as existing sections |
 
-### Proof Artifacts
+### Proof Artifacts (Unit 2)
 
 | # | Artifact | Status | Evidence |
 |---|---|---|---|
@@ -103,11 +103,12 @@
 
 ### Test Script: `scripts/test-no-direct-commits-hook.sh`
 
-```
+```text
 Results: 11 passed, 0 failed
 ```
 
 All 11 checks passed:
+
 1. Hook entry found in .pre-commit-config.yaml
 2. Hook field 'id' = 'no-direct-commits-to-main'
 3. Hook field 'language' = 'system'
@@ -122,6 +123,6 @@ All 11 checks passed:
 
 ### Markdownlint
 
-```
+```text
 markdownlint.............................................................Passed
 ```


### PR DESCRIPTION
## Summary
- `pre-commit run --all-files` currently fails `markdownlint` on `main` due to pre-existing violations in the spec/proof docs
- Added `text`/`console` language hints to fenced code/log blocks (MD040)
- Disambiguated duplicate `### Functional Requirements` / `### Proof Artifacts` headings in `docs/specs/02-spec-no-direct-commits-to-main/validation-report.md` by appending `(Unit 1)` / `(Unit 2)` (MD024)
- Formatting only — no content changes

## Test plan
- [x] `pre-commit run markdownlint --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation formatting only; no application, CI workflow, or hook behavior changes.
> 
> **Overview**
> Fixes **markdownlint** failures in performance-testing and no-direct-commits spec/proof docs so `pre-commit run --all-files` can pass on `main`.
> 
> Fenced blocks that lacked a language tag now use **`text`** or **`console`** (MD040) in the performance CI proof/validation files and in the branch-protection validation report’s log excerpts.
> 
> In **`validation-report.md`**, duplicate **`### Functional Requirements`** and **`### Proof Artifacts`** headings are disambiguated with **`(Unit 1)`** / **`(Unit 2)`** (MD024); one hook name is capitalized for consistency and a blank line is added before a numbered list. **No substantive documentation content was changed.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d1215890be1ec78c5a3a8805e71c3df47156258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->