### PR TITLE
fix(docs): remove unintended agent file imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,10 @@ The marker for this instruction is: 🤖
 
 Refer to these comprehensive guides for detailed information:
 
-- @docs/DEVELOPMENT.md — **[Development Guide](docs/DEVELOPMENT.md)** - TDD workflow, setup, and development process
-- @docs/TESTING.md — **[Testing Guide](docs/TESTING.md)** - Testing strategies, patterns, and TDD implementation
-- @docs/ARCHITECTURE.md — **[Architecture Guide](docs/ARCHITECTURE.md)** - System design and technical decisions
-- @docs/PRECOMMIT.md — **[Pre-commit Guide](docs/PRECOMMIT.md)** - Hook configuration, usage, and troubleshooting
+- docs/DEVELOPMENT.md — **[Development Guide](docs/DEVELOPMENT.md)** - TDD workflow, setup, and development process
+- docs/TESTING.md — **[Testing Guide](docs/TESTING.md)** - Testing strategies, patterns, and TDD implementation
+- docs/ARCHITECTURE.md — **[Architecture Guide](docs/ARCHITECTURE.md)** - System design and technical decisions
+- docs/PRECOMMIT.md — **[Pre-commit Guide](docs/PRECOMMIT.md)** - Hook configuration, usage, and troubleshooting
 
 ## TDD Standards
 


### PR DESCRIPTION
## Summary
- Remove `@` prefixes from the four documentation references in `AGENTS.md` so they remain navigable links without being eagerly loaded into every agent context.
- Reduce initial context usage from 57k to 29.4k tokens; memory-file usage falls from 25.1k to 4.1k tokens.
- Preserve meaningful headroom before the context window reaches the ~200k-token “dumb zone,” where response quality begins to degrade.

## Evidence
Comparison of the output of `/context all` before and after this change:

<img width="1332" height="1058" alt="image" src="https://github.com/user-attachments/assets/02be7867-9b51-43c4-8114-b2c3c39ae217" />


## Testing
- `pre-commit run`
- Commit hooks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit in `AGENTS.md` with no application, auth, or data-path changes.
> 
> **Overview**
> Updates the **Documentation Structure** section in `AGENTS.md` so the four guide references (`docs/DEVELOPMENT.md`, `docs/TESTING.md`, `docs/ARCHITECTURE.md`, `docs/PRECOMMIT.md`) use plain paths instead of `@`-prefixed paths.
> 
> That stops those files from being treated as automatic agent imports while keeping the same markdown links for humans. The intent is lower default context usage (the linked guides are no longer pulled into memory on every session).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1adf1dc8820d94002c19e5860c4f5c95176a5a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guide links in the contributor documentation for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->