### PR TITLE
chore(deps): bump Spring Boot to 4.1.0 and refresh Maven plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.0</version>
+    <version>4.1.0</version>
   </parent>
   <groupId>org.springframework.samples</groupId>
   <artifactId>spring-petclinic</artifactId>
@@ -20,12 +20,12 @@
     <project.build.outputTimestamp>2024-11-28T14:37:52Z</project.build.outputTimestamp>
 
     <!-- Web dependencies -->
-    <webjars-locator.version>1.1.2</webjars-locator.version>
+    <webjars-locator.version>1.1.3</webjars-locator.version>
     <webjars-bootstrap.version>5.3.8</webjars-bootstrap.version>
     <webjars-font-awesome.version>4.7.0</webjars-font-awesome.version>
 
     <checkstyle.version>12.1.2</checkstyle.version>
-    <jacoco.version>0.8.14</jacoco.version>
+    <jacoco.version>0.8.15</jacoco.version>
     <libsass.version>0.3.4</libsass.version>
     <lifecycle-mapping>1.0.0</lifecycle-mapping>
     <maven-checkstyle.version>3.6.0</maven-checkstyle.version>
@@ -455,7 +455,7 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>3.6.3</version>
             <executions>
               <execution>
                 <id>check-thresholds</id>


### PR DESCRIPTION
Routine dependency maintenance, kept separate from the build-gate changes
that follow so a bisect can tell a version bump apart from a new gate.

- spring-boot-starter-parent 4.0.0 -> 4.1.0
- webjars-locator 1.1.2 -> 1.1.3
- jacoco-maven-plugin 0.8.14 -> 0.8.15
- exec-maven-plugin 3.3.0 -> 3.6.3 (performance profile)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spring Boot minor upgrades can change transitive dependencies and framework behavior; risk is moderate despite a small diff because the whole stack inherits from the parent BOM.
> 
> **Overview**
> **Dependency-only maintenance** in `pom.xml`, with no application or test source changes.
> 
> The parent **`spring-boot-starter-parent`** moves **4.0.0 → 4.1.0**, which pulls in updated Spring Boot BOM-managed dependency and plugin versions. Explicit property bumps: **`webjars-locator`** 1.1.2 → 1.1.3, **`jacoco`** 0.8.14 → 0.8.15. In the **`performance`** profile, **`exec-maven-plugin`** is updated **3.3.0 → 3.6.3** for the JMeter threshold check execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea1b7b47a0c6f3b212119ccd775e58901f830a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->