### PR TITLE
chore(deps): align Testcontainers DB images with docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:9.5
+    image: mysql:9.7
     ports:
       - "3306:3306"
     environment:
@@ -12,7 +12,7 @@ services:
     volumes:
       - "./conf.d:/etc/mysql/conf.d:ro"
   postgres:
-    image: postgres:18.1
+    image: postgres:18.4
     ports:
       - "5432:5432"
     environment:

--- a/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
@@ -47,7 +47,7 @@ class MySqlIntegrationTests {
 
 	@ServiceConnection
 	@Container
-	static MySQLContainer container = new MySQLContainer(DockerImageName.parse("mysql:9.5"));
+	static MySQLContainer container = new MySQLContainer(DockerImageName.parse("mysql:9.7"));
 
 	@LocalServerPort
 	int port;

--- a/src/test/java/org/springframework/samples/petclinic/MysqlTestApplication.java
+++ b/src/test/java/org/springframework/samples/petclinic/MysqlTestApplication.java
@@ -36,7 +36,7 @@ public class MysqlTestApplication {
 	@Profile("mysql")
 	@Bean
 	static MySQLContainer container() {
-		return new MySQLContainer(DockerImageName.parse("mysql:9.5"));
+		return new MySQLContainer(DockerImageName.parse("mysql:9.7"));
 	}
 
 	public static void main(String[] args) {

--- a/src/test/java/org/springframework/samples/petclinic/PostgresIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PostgresIntegrationTests.java
@@ -62,7 +62,7 @@ public class PostgresIntegrationTests {
 	@ServiceConnection
 	@Container
 	private static final PostgreSQLContainer<?> container = new PostgreSQLContainer<>(
-			DockerImageName.parse("postgres:18.1"));
+			DockerImageName.parse("postgres:18.4"));
 
 	@LocalServerPort
 	int port;

--- a/src/test/java/org/springframework/samples/petclinic/PostgresSequenceResetIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PostgresSequenceResetIntegrationTests.java
@@ -48,7 +48,7 @@ class PostgresSequenceResetIntegrationTests {
 
 	@ServiceConnection
 	@Container
-	static PostgreSQLContainer container = new PostgreSQLContainer(DockerImageName.parse("postgres:18.1"));
+	static PostgreSQLContainer container = new PostgreSQLContainer(DockerImageName.parse("postgres:18.4"));
 
 	@Autowired
 	private DataSource dataSource;


### PR DESCRIPTION
docker-compose.yml and the Testcontainers-based integration tests pin the
database images independently, so they drift: Dependabot's docker-compose
ecosystem cannot see the Java string literals in the test sources. Bump
both together so local compose and the integration tests exercise the same
database versions.

- mysql 9.5 -> 9.7 (docker-compose.yml, MySqlIntegrationTests,
  MysqlTestApplication)
- postgres 18.1 -> 18.4 (docker-compose.yml, PostgresIntegrationTests,
  PostgresSequenceResetIntegrationTests)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bumps in dev/test infrastructure with no application or production code changes.
> 
> **Overview**
> Bumps pinned MySQL and PostgreSQL Docker images so **docker-compose** and **Testcontainers** integration tests use the same versions.
> 
> **MySQL** moves from `9.5` to `9.7` in `docker-compose.yml`, `MySqlIntegrationTests`, and `MysqlTestApplication`. **PostgreSQL** moves from `18.1` to `18.4` in `docker-compose.yml`, `PostgresIntegrationTests`, and `PostgresSequenceResetIntegrationTests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f596682ef561bfe654b0b67de3e92f34c6d65b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->