### PR TITLE
fix(security): prevent Pet primary-key over-posting in PetController

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -93,6 +93,7 @@ class PetController {
 
 	@InitBinder("pet")
 	void initPetBinder(WebDataBinder dataBinder) {
+		dataBinder.setDisallowedFields("id");
 		dataBinder.setValidator(new PetValidator());
 	}
 

--- a/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/PetControllerTests.java
@@ -33,6 +33,7 @@ import org.springframework.test.context.aot.DisabledInAotMode;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -65,6 +66,10 @@ class PetControllerTests {
 	@MockitoBean
 	private PetTypeRepository types;
 
+	// The pet loaded for TEST_PET_ID; kept as a field so tests can assert the
+	// controller never lets a request rebind its persistent primary key.
+	private Pet petty;
+
 	@BeforeEach
 	void setup() {
 		PetType cat = new PetType();
@@ -81,6 +86,7 @@ class PetControllerTests {
 		dog.setId(TEST_PET_ID + 1);
 		pet.setName("petty");
 		dog.setName("doggy");
+		this.petty = pet;
 		given(this.owners.findById(TEST_OWNER_ID)).willReturn(Optional.of(owner));
 	}
 
@@ -110,6 +116,23 @@ class PetControllerTests {
 				.param("birthDate", "2015-02-12"))
 			.andExpect(status().is3xxRedirection())
 			.andExpect(view().name("redirect:/owners/{ownerId}"));
+	}
+
+	@Test
+	void testProcessUpdateFormIgnoresOverPostedId() throws Exception {
+		// The pet id is derived from the path via findPet, never the request body.
+		// Over-posting a different "id" must be dropped by the pet binder's
+		// setDisallowedFields("id"), leaving the loaded pet's primary key intact.
+		this.mockMvc
+			.perform(post("/owners/{ownerId}/pets/{petId}/edit", TEST_OWNER_ID, TEST_PET_ID)
+				.param("id", String.valueOf(TEST_PET_ID + 1))
+				.param("name", "Betty")
+				.param("type", "hamster")
+				.param("birthDate", "2015-02-12"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(view().name("redirect:/owners/{ownerId}"));
+
+		assertThat(this.petty.getId()).isEqualTo(TEST_PET_ID);
 	}
 
 	@Nested


### PR DESCRIPTION
PetController.initPetBinder installed only the validator, so unlike the
owner and visit binders it left the Pet "id" bindable. A POST to
/owners/{ownerId}/pets/{petId}/edit carrying an "id" parameter rebound the
loaded pet's primary key, and updatePetDetails then edited whichever pet
matched the over-posted id -- letting a request edit a sibling pet it was
never routed to.

- test: RED test asserting the loaded pet's id survives an over-posted id
  (fails with "expected: 1" before the fix)
- fix: disallow "id" on the @InitBinder("pet") binder, matching
  initOwnerBinder

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive binding fix on pet edit; change is small and mirrored from existing owner binder behavior, with a targeted regression test.
> 
> **Overview**
> **Closes a mass-assignment gap on pet updates:** the `@InitBinder("pet")` handler now calls `setDisallowedFields("id")`, aligned with the owner binder, so request parameters cannot rebind the loaded pet’s primary key.
> 
> Without that, a POST to `/owners/{ownerId}/pets/{petId}/edit` could include a different `id` and `updatePetDetails` would apply changes to whichever sibling pet matched the over-posted id.
> 
> A new MockMvc test posts a conflicting `id` on update and asserts the in-memory pet loaded for the path still has the original id after redirect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d5fe96e97bc9867dbd3c41ba9211084e9cd992a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->