### PR TITLE
build: gate `mvnw verify` on coverage, enforcer rules, and SpotBugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Emerald Grove Veterinary Clinic application manages the core operations of a
 ### Prerequisites
 
 - **Java 25** or later
-- **Maven 3.6+** (or use the bundled `./mvnw` wrapper)
+- **Maven 3.9+** (or use the bundled `./mvnw` wrapper)
 
 ### Run Application
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,7 +5,7 @@ This guide covers development setup, testing, and contribution guidelines for th
 ## Prerequisites
 
 - **Java 25** or later
-- **Maven 3.6+** (or use the bundled `./mvnw` wrapper)
+- **Maven 3.9+** (or use the bundled `./mvnw` wrapper)
 - **Git** for version control
 - **Docker** (optional, for containerized databases)
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,13 @@
       maven-checkstyle-plugin, so the build (and CI) must run on JDK 21+ or every checkstyle execution
       dies with UnsupportedClassVersionError. The java.version 25 floor above covers this. -->
     <checkstyle.version>13.7.0</checkstyle.version>
+    <findsecbugs.version>1.14.0</findsecbugs.version>
     <jacoco.version>0.8.15</jacoco.version>
     <libsass.version>0.3.4</libsass.version>
     <lifecycle-mapping>1.0.0</lifecycle-mapping>
     <maven-checkstyle.version>3.6.0</maven-checkstyle.version>
     <nohttp-checkstyle.version>0.0.11</nohttp-checkstyle.version>
+    <spotbugs-maven-plugin.version>4.10.2.0</spotbugs-maven-plugin.version>
     <spring-format.version>0.0.47</spring-format.version>
   </properties>
 
@@ -185,6 +187,13 @@
                   <message>This build requires at least Java ${java.version}, update your JVM, and run the build again</message>
                   <version>${java.version}</version>
                 </requireJavaVersion>
+                <requireMavenVersion>
+                  <message>This build requires at least Maven 3.9 (the project ships Maven 3.9.11 via the wrapper)</message>
+                  <version>[3.9,)</version>
+                </requireMavenVersion>
+                <banDuplicatePomDependencyVersions/>
+                <requireUpperBoundDeps/>
+                <dependencyConvergence/>
               </rules>
             </configuration>
           </execution>
@@ -296,6 +305,60 @@
               <goal>report</goal>
             </goals>
             <phase>prepare-package</phase>
+          </execution>
+          <execution>
+            <id>check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <!-- Baseline-ratchet floor. Current line coverage is ~94%; the floor is set to
+                the 90% documented in AGENTS.md, leaving headroom. Ratchet upward over time. -->
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.90</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- SpotBugs static bytecode analysis + FindSecBugs security detectors.
+        Complements Checkstyle (style-only). Gates the build at the verify phase. -->
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>${spotbugs-maven-plugin.version}</version>
+        <configuration>
+          <effort>Max</effort>
+          <threshold>Medium</threshold>
+          <failOnError>true</failOnError>
+          <includeTests>false</includeTests>
+          <excludeFilterFile>${basedir}/src/spotbugs/spotbugs-exclude.xml</excludeFilterFile>
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>${findsecbugs.version}</version>
+            </plugin>
+          </plugins>
+        </configuration>
+        <executions>
+          <execution>
+            <id>spotbugs-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
           </execution>
         </executions>
       </plugin>

--- a/src/spotbugs/spotbugs-exclude.xml
+++ b/src/spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SpotBugs exclude filter for Emerald Grove Veterinary Clinic.
+
+  Only idiomatic Spring / JPA patterns that SpotBugs reports as bugs but are
+  non-issues for a reference CRUD application belong here. Each <Match> carries
+  a comment explaining why it is safe to suppress. Genuine bugs (and all
+  FindSecBugs security findings that are NOT already mitigated) must be fixed in
+  code, not suppressed. Matches are scoped narrowly (bug pattern + package/class)
+  so unrelated new findings still fail the build.
+-->
+<FindBugsFilter>
+
+  <!--
+    EI_EXPOSE_REP / EI_EXPOSE_REP2: JPA entities and view beans intentionally
+    share references to their persistent collections and associations. Returning
+    or storing defensive copies would break Hibernate dirty-checking and lazy
+    loading (and the JAXB-bound vet list view). Idiomatic and safe for a
+    reference domain model. Scoped to the domain packages only.
+  -->
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2"/>
+    <Package name="~org\.springframework\.samples\.petclinic\.(owner|vet|model)"/>
+  </Match>
+
+  <!--
+    ENTITY_MASS_ASSIGNMENT: the Spring MVC form controllers bind request
+    parameters onto JPA entities by design (server-rendered CRUD forms).
+    Over-posting of the primary key is already mitigated: every binder that
+    populates an entity calls setDisallowedFields("id") — OwnerController and
+    VisitController via a default @InitBinder, and PetController via both its
+    named @InitBinder("owner") and @InitBinder("pet"). FindSecBugs flags the
+    data-binding pattern regardless of that binder mitigation, so it is a false
+    positive here. Scoped to the owner-package controllers only.
+  -->
+  <Match>
+    <Bug pattern="ENTITY_MASS_ASSIGNMENT"/>
+    <Class name="~org\.springframework\.samples\.petclinic\.owner\..*Controller"/>
+  </Match>
+
+</FindBugsFilter>


### PR DESCRIPTION
`mvnw verify` ran the tests but asserted nothing about coverage, dependency
hygiene, or bytecode-level defects, so regressions in any of those were
invisible until someone looked. Add the three gates. All pass as-is:
60 tests, 94.3% line coverage, 0 SpotBugs findings.

- jacoco:check at verify with a 90% BUNDLE line-coverage floor -- a ratchet
  baseline matching the number already documented in AGENTS.md, with ~4%
  headroom against current coverage
- enforcer: requireMavenVersion [3.9,), banDuplicatePomDependencyVersions,
  requireUpperBoundDeps, and dependencyConvergence, so a transitive version
  conflict fails the build instead of resolving silently
- spotbugs-maven-plugin (effort Max, threshold Medium) with the FindSecBugs
  detector pack, gating at verify
- src/spotbugs/spotbugs-exclude.xml suppressing only the two idiomatic
  Spring/JPA patterns that are genuine false positives here, each scoped to
  a bug pattern plus package so unrelated findings still fail
- document the Maven 3.9+ floor the enforcer now requires

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and CI configuration only; no runtime application code changes. Stricter verify may fail older Maven or under-covered PRs until fixed.
> 
> **Overview**
> **`mvnw verify` now fails the build** on coverage, dependency hygiene, and bytecode/security static analysis instead of only running tests.
> 
> JaCoCo **`check`** runs at **verify** with a **90% bundle line-coverage** minimum (ratchet baseline aligned with project docs). The Maven **enforcer** gains **Maven 3.9+**, **ban duplicate POM dependency versions**, **require upper-bound deps**, and **dependency convergence**. **SpotBugs** (max effort, medium threshold) plus **FindSecBugs** runs at **verify** with **`failOnError`**, using a new **`spotbugs-exclude.xml`** that narrowly suppresses known Spring/JPA false positives (entity exposure and owner-controller mass-assignment).
> 
> **README** and **DEVELOPMENT** prerequisites are updated from Maven 3.6+ to **3.9+** to match the enforcer rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82bf3c16a4a6fb03f432cfb51ed2c999d9d99ef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->