### PR TITLE
chore(precommit): get the hook set green and pin every hook by SHA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 repos:
   # Basic file and text processing hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # v6.0.0
     hooks:
       - id: trailing-whitespace
         description: Removes trailing whitespace
@@ -33,33 +33,41 @@ repos:
       - id: mixed-line-ending
         description: Ensures consistent line endings
         args: ["--fix=lf"]
+        # .gitattributes deliberately checks *.cmd/*.bat out as CRLF, so --fix=lf
+        # rewrites them on every run and the hook can never pass. Leave those to
+        # git's own eol normalization.
+        exclude: \.(cmd|bat)$
 
   # Documentation hooks
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.39.0
+    rev: a4d5d37e66ebcd6b3705204a1d6dbb56dea66338  # v0.49.0
     hooks:
       - id: markdownlint
         description: Lints Markdown files
         args: ["--config", ".markdownlint.yaml", "--fix"]
+        # SDD spec/proof artifacts under docs/specs are point-in-time generated
+        # records, not maintained prose. They are already excluded from review in
+        # .coderabbit.yaml; hold them to the same standard here so a regenerated
+        # spec cannot block an unrelated commit.
+        exclude: ^docs/specs/
 
   # Security and dependency checks
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.3.2
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e  # v8.30.1
     hooks:
-      - id: python-safety-dependencies-check
-        description: Checks Python dependencies for security vulnerabilities
-        files: requirements.*\.txt$
+      - id: gitleaks
+        description: Detects hardcoded secrets (keys, tokens, credentials) in staged changes
 
   # Shell script hooks
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.6
+    rev: 745eface02aef23e168a8afb6b5737818efbea95  # v0.11.0.1
     hooks:
       - id: shellcheck
         description: Lints shell scripts for common issues
 
   # Git hooks
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.19.0
+    rev: acc9d9de6369b76d22cb4167029d2035e8730b98  # v0.19.1
     hooks:
       - id: gitlint
         description: Lints commit messages
@@ -68,6 +76,14 @@ repos:
   # Spring Boot specific hooks
   - repo: local
     hooks:
+      - id: spring-javaformat-apply
+        name: Spring Java Format (auto-apply)
+        entry: ./mvnw -q spring-javaformat:apply
+        language: system
+        files: '\.java$'
+        pass_filenames: false
+        stages: [pre-commit]
+        description: Auto-formats Java sources to Spring conventions; if files are modified, re-stage them and retry the commit
       - id: maven-test-check
         name: Maven test check
         entry: ./mvnw test
@@ -92,6 +108,10 @@ repos:
         description: Prevents direct commits to the main branch, enforcing a PR-based workflow
 
 # Configuration options
+# Install both hook types so a bare `pre-commit install` also wires up the
+# commit-msg hooks (gitlint, no-direct-commits-to-main); otherwise they only
+# run after `pre-commit install --hook-type commit-msg`.
+default_install_hook_types: [pre-commit, commit-msg]
 default_stages: [pre-commit]
 fail_fast: false
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -269,13 +269,6 @@ Build a Docker image using Spring Boot build plugin:
 - Add JavaDoc for public APIs
 - Keep methods small and focused
 
-Formatting is enforced by [spring-javaformat](https://github.com/spring-io/spring-javaformat)
-(validated at the Maven `validate` phase). Run `./mvnw spring-javaformat:apply` to
-auto-fix any formatting violations before committing — the pre-commit hook also
-runs this automatically. Installing the
-spring-javaformat IDE plugin (Eclipse/IntelliJ/VS Code) formats on save to the
-same rules.
-
 ### Testing Guidelines
 
 - Write unit tests for business logic

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -271,7 +271,8 @@ Build a Docker image using Spring Boot build plugin:
 
 Formatting is enforced by [spring-javaformat](https://github.com/spring-io/spring-javaformat)
 (validated at the Maven `validate` phase). Run `./mvnw spring-javaformat:apply` to
-auto-fix any formatting violations before committing. Installing the
+auto-fix any formatting violations before committing — the pre-commit hook also
+runs this automatically. Installing the
 spring-javaformat IDE plugin (Eclipse/IntelliJ/VS Code) formats on save to the
 same rules.
 

--- a/docs/PRECOMMIT.md
+++ b/docs/PRECOMMIT.md
@@ -21,11 +21,9 @@ Pre-commit hooks are automated checks that run before each commit to ensure code
 # Install pre-commit (if not already installed)
 pipx install pre-commit
 
-# Install the hooks
+# Install the hooks (config's default_install_hook_types wires up both
+# the pre-commit and commit-msg stages, so a single install is enough)
 pre-commit install
-
-# Install commit-msg hook
-pre-commit install --hook-type commit-msg
 ```
 
 ## Available Hooks
@@ -45,6 +43,7 @@ pre-commit install --hook-type commit-msg
 
 ### Java Specific
 
+- **spring-javaformat-apply**: Auto-formats Java sources to Spring conventions (`./mvnw spring-javaformat:apply`); if it reformats files, re-stage them and commit again
 - **Maven-test-check**: Runs the full test suite and ensures all tests pass before committing
 
 ### Documentation
@@ -53,6 +52,7 @@ pre-commit install --hook-type commit-msg
 
 ### Security & Quality
 
+- **gitleaks**: Detects hardcoded secrets (keys, tokens, credentials) in staged changes
 - **shellcheck**: Lints shell scripts
 - **gitlint**: Validates commit messages
 


### PR DESCRIPTION
`pre-commit run --all-files` failed out of the box on main, so the hooks were
effectively opt-out. Fix the failures, replace the dead Python hook with one
that matches this repo's languages, and pin mutable tags to SHAs.

- pin every rev to a commit SHA with the tag in a trailing comment, so a
  retagged upstream release cannot silently change what runs locally
- bump pre-commit-hooks v4.5.0 -> v6.0.0, markdownlint-cli v0.39.0 -> v0.49.0,
  shellcheck-py v0.9.0.6 -> v0.11.0.1, gitlint v0.19.0 -> v0.19.1
- replace python-safety-dependencies-check with gitleaks: the old hook only
  scanned requirements*.txt, of which this repo has none, so it never ran.
  Secret scanning applies to every language here
- add a spring-javaformat-apply hook so formatting self-heals locally instead
  of failing at the Maven validate gate
- set default_install_hook_types so a bare `pre-commit install` also wires the
  commit-msg stage; previously gitlint and no-direct-commits-to-main silently
  did nothing unless you knew to pass --hook-type commit-msg
- exclude *.cmd/*.bat from mixed-line-ending. .gitattributes checks them out
  as CRLF, so --fix=lf rewrote them on every run and the hook could never
  pass (pre-existing on main, not caused by the version bumps)
- exclude docs/specs from markdownlint. Those are generated point-in-time SDD
  artifacts, already excluded from review in .coderabbit.yaml, and 23 lint
  errors in them would otherwise block every unrelated commit

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer tooling and documentation only; no application runtime, auth, or data-path changes.
> 
> **Overview**
> Makes local pre-commit reliable again by pinning every third-party hook to a **commit SHA** (with the release tag in a comment) and bumping several hook versions so `pre-commit run --all-files` can pass on main.
> 
> **Security and Java workflow:** Replaces the unused `python-safety-dependencies-check` (only scanned `requirements*.txt`, which this repo does not have) with **gitleaks** for secret scanning on staged changes. Adds a **spring-javaformat-apply** local hook so Java formatting is fixed at commit time instead of only failing later at Maven `validate`.
> 
> **Install and exclusions:** Sets `default_install_hook_types` so a single `pre-commit install` wires **commit-msg** hooks (`gitlint`, block direct commits to `main`). Excludes `*.cmd`/`*.bat` from `mixed-line-ending` (CRLF vs `--fix=lf` loop) and **`docs/specs/`** from markdownlint (generated SDD artifacts, aligned with `.coderabbit.yaml`).
> 
> **Docs:** `docs/PRECOMMIT.md` documents the new hooks and simplified install; `docs/DEVELOPMENT.md` drops the standalone spring-javaformat paragraph from Code Style (formatting is now covered via pre-commit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d29f11487523db60a7de0c2f66851c0cf812dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->