### PR TITLE
chore(build): target Java 25 LTS and align dev/CI toolchains

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,13 @@
-# Not actually used by the devcontainer, but it is used by gitpod
+# Not actually used by the devcontainer, but it is used by gitpod.
+# NOTE: this base image family is frozen at JDK 17; the effective JDK used by
+# the build is installed and selected via SDKMAN below (see JAVA_VERSION).
 ARG VARIANT=17-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/java:0-${VARIANT}
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 ARG USER=vscode
 VOLUME /home/$USER/.m2
-ARG JAVA_VERSION=17.0.7-ms
-RUN sudo mkdir /home/$USER/.m2 && sudo chown $USER:$USER /home/$USER/.m2
-RUN bash -lc '. /usr/local/sdkman/bin/sdkman-init.sh && sdk install java $JAVA_VERSION && sdk use java $JAVA_VERSION'
+# Installs Temurin 26, which satisfies the pom.xml java.version >= 25 floor.
+ARG JAVA_VERSION=26.0.1-tem
+RUN mkdir /home/$USER/.m2 && chown $USER:$USER /home/$USER/.m2
+RUN bash -lc '. /usr/local/sdkman/bin/sdkman-init.sh && sdk install java $JAVA_VERSION && sdk default java $JAVA_VERSION'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,8 @@
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
     "ghcr.io/devcontainers/features/java:1": {
-      "version": "21-oracle",
-      "jdkDistro": "oracle"
+      "version": "26",
+      "jdkDistro": "tem"
     },
     "ghcr.io/devcontainers/features/azure-cli:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '25'
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '25'
 
       - name: Build application
         run: ./mvnw package -DskipTests

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Emerald Grove Veterinary Clinic application manages the core operations of a
 
 ### Prerequisites
 
-- **Java 17** or later
+- **Java 25** or later
 - **Maven 3.6+** (or use the bundled `./mvnw` wrapper)
 
 ### Run Application

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This guide covers development setup, testing, and contribution guidelines for th
 
 ## Prerequisites
 
-- **Java 17** or later
+- **Java 25** or later
 - **Maven 3.6+** (or use the bundled `./mvnw` wrapper)
 - **Git** for version control
 - **Docker** (optional, for containerized databases)
@@ -282,7 +282,7 @@ Build a Docker image using Spring Boot build plugin:
 
 #### Build fails with Java version error
 
-- Ensure Java 17+ is installed and active
+- Ensure Java 25+ is installed and active
 - Check `JAVA_HOME` environment variable
 
 #### Database connection errors

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -682,10 +682,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '25'
     - name: Run tests
       run: ./mvnw test
     - name: Generate coverage report
@@ -808,7 +808,7 @@ This repository includes a standalone Playwright + TypeScript E2E suite under `e
 
 ### Prerequisites
 
-- Java 17+
+- Java 25+
 - Node.js + npm
 - (Recommended) Docker if you run DB profiles, though default H2 works fine
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <!-- Generic properties -->
-    <java.version>17</java.version>
+    <java.version>25</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Important for reproducible builds. Update using e.g. ./mvnw versions:set -DnewVersion=... -->


### PR DESCRIPTION
The build targeted Java 17 while the devcontainer provisioned 21 and the
gitpod image 17.0.7, so three environments disagreed about the JDK. Move the
floor to Java 25 (the current LTS) and point every environment at a JDK that
satisfies it. `./mvnw verify` passes: 59 tests.

This lands early in the stack deliberately: the Spring Checkstyle gate added
later needs Checkstyle 13.x, which is compiled for Java 21, so CI has to be
on a modern JDK before that gate arrives.

- pom.xml java.version 17 -> 25; the existing enforcer requireJavaVersion
  rule now fails fast on an older JVM
- devcontainer.json: Java feature 21-oracle -> Temurin 26
- gitpod Dockerfile: SDKMAN JAVA_VERSION 17.0.7-ms -> 26.0.1-tem, and
  `sdk default` instead of `sdk use` so the selection survives a new shell.
  The base image family is frozen at JDK 17, so a comment now records that
  SDKMAN supplies the effective JDK
- bump the JDK in the existing e2e and performance workflows to 25, without
  which they cannot compile the new target
- update the Java version in README, DEVELOPMENT, and TESTING

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> No runtime logic changes, but every contributor and CI job must use Java 25+, which can break local builds until toolchains are upgraded.
> 
> **Overview**
> Raises the **minimum Java version from 17 to 25** in `pom.xml`, so the existing Maven enforcer rule rejects older JVMs on the next build.
> 
> **Dev and CI** are updated to match: devcontainer uses **Temurin 26** (Java feature + Gitpod Dockerfile via SDKMAN with `sdk default`); **e2e** and **performance** GitHub Actions workflows use **Temurin 25**. README, DEVELOPMENT, and TESTING docs now say Java 25+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a64b69ba39978d31ea6ff827c87c05d0e73b61d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->